### PR TITLE
Bugfix: Spacedust is inconsistently rendered

### DIFF
--- a/src/screenComponents/viewport3d.cpp
+++ b/src/screenComponents/viewport3d.cpp
@@ -262,20 +262,28 @@ void GuiViewport3D::onDraw(sf::RenderTarget& window)
     {
         static std::vector<sf::Vector3f> space_dust;
 
-        while(space_dust.size() < 1000)
+        while(space_dust.size() < 3000)
             space_dust.push_back(sf::Vector3f());
 
         sf::Vector2f dust_vector = my_spaceship->getVelocity() / 100.0f;
-        sf::Vector3f dust_center = sf::Vector3f(my_spaceship->getPosition().x, my_spaceship->getPosition().y, my_spaceship->getPositionZ());
-        glColor4f(0.7, 0.5, 0.35, 0.07);
+        sf::Vector3f dust_center = sf::Vector3f(my_spaceship->getPosition().x, my_spaceship->getPosition().y, 0.0f); 
+        glColor4f(1, 0.95, 0.81, 0.7);
 
-        for(unsigned int n=0; n<space_dust.size(); n++)
+        for (unsigned int n = 0; n < space_dust.size(); n++)
         {
             const float maxDustDist = 500.0f;
-            const float minDustDist = 100.0f;
+            const float minDustDist = 10.0f;
             glPushMatrix();
-            if ((space_dust[n] - dust_center) > maxDustDist || (space_dust[n] - dust_center) < minDustDist)
-                space_dust[n] = dust_center + sf::Vector3f(random(-maxDustDist, maxDustDist), random(-maxDustDist, maxDustDist), random(-maxDustDist, maxDustDist));
+
+            auto delta = space_dust[n] - dust_center;
+            if (delta > maxDustDist || delta < minDustDist)
+            {
+                // TODO [SBW]: Weight dust generation to favour the direction of movement
+                space_dust[n] = dust_center + sf::Vector3f(
+                    random(-maxDustDist, maxDustDist), 
+                    random(-maxDustDist, maxDustDist), 
+                    random(-maxDustDist, maxDustDist));
+            }
             glTranslatef(space_dust[n].x, space_dust[n].y, space_dust[n].z);
             glBegin(GL_LINES);
             glVertex3f(-dust_vector.x, -dust_vector.y, 0);

--- a/src/screenComponents/viewportMainScreen.cpp
+++ b/src/screenComponents/viewportMainScreen.cpp
@@ -14,6 +14,7 @@ GuiViewportMainScreen::GuiViewportMainScreen(GuiContainer* owner, string id)
     if (flags & flag_spacedust)
         showSpacedust();
 
+    // Logic for this flag has been inverted, so "first_person" is actually the third-person view
     first_person = PreferencesManager::get("first_person") == "1";
 }
 
@@ -43,8 +44,9 @@ void GuiViewportMainScreen::onDraw(sf::RenderTarget& window)
         float camera_ship_height = 420.0f + my_spaceship->getPositionZ();
         if (!first_person)
         {
+            // SBW: Hardcoded camera height for consistent stardust experience between ship-classes
             camera_ship_distance = -my_spaceship->getRadius();
-            camera_ship_height = my_spaceship->getRadius() / 10.f + my_spaceship->getPositionZ();
+            camera_ship_height = 15.0f;
             camera_pitch = 0;
         }
         sf::Vector2f cameraPosition2D = my_spaceship->getPosition() + sf::vector2FromAngle(target_camera_yaw) * -camera_ship_distance;


### PR DESCRIPTION
- On some ships, spacedust appears very pale and translucent. Varies by ship and scenario, so the same ship in different scenarios (or even in the same scenario) may have very pale and translucent dust and feel like it isn't moving.

- Workaround is to increase the quanity, opacity, and shade of dust so it is always visible on all ships.