### PR TITLE
Tutorial menu is now harder to exit

### DIFF
--- a/src/menus/tutorialMenu.cpp
+++ b/src/menus/tutorialMenu.cpp
@@ -62,14 +62,6 @@ TutorialMenu::TutorialMenu()
     });
     start_tutorial_button->setEnable(false)->setPosition(0, 0, ABottomRight)->setSize(300, GuiElement::GuiSizeMax);
 
-    // Back button.
-    (new GuiButton(bottom_row, "BACK", tr("Back"), [this]()
-    {
-        // Close this menu, stop the music, and return to the main menu.
-        destroy();
-        returnToMainMenu();
-    }))->setPosition(0, 0, ABottomLeft)->setSize(300, GuiElement::GuiSizeMax);
-
     // Select the first scenario in the list by default.
     if (!tutorial_filenames.empty()) {
         tutorial_list->setSelectionIndex(0);

--- a/src/tutorialGame.cpp
+++ b/src/tutorialGame.cpp
@@ -1,5 +1,6 @@
 #include <i18n.h>
 #include "tutorialGame.h"
+#include "menus/tutorialMenu.h"
 #include "scriptInterface.h"
 #include "playerInfo.h"
 #include "spaceObjects/playerSpaceship.h"
@@ -254,7 +255,7 @@ void TutorialGame::finish()
         destroy();
 
         disconnectFromServer();
-        returnToMainMenu();
+        new TutorialMenu();
     }
 }
 


### PR DESCRIPTION
- Removed "Back" button from tutorial menu
- Finishing a tutorial re-opens the tutorial menu
- Only way to exit the tutorial menu is now by pressing ESC