### PR TITLE
Fix drone docking button

### DIFF
--- a/src/screenComponents/dockingButton.cpp
+++ b/src/screenComponents/dockingButton.cpp
@@ -95,9 +95,11 @@ P<SpaceObject> GuiDockingButton::findDockingTarget()
     foreach(Collisionable, obj, obj_list)
     {
         dock_object = obj;
-            // SBW: Using sf library instead of glm
-            if (dock_object && dock_object != my_spaceship && dock_object->canBeDockedBy(my_spaceship) != DockStyle::None && sf::length(dock_object->getPosition() - my_spaceship->getPosition()) < 1000.0f + dock_object->getRadius())
+
+        // NB: Aligning logic to use target_spaceship rather than my_spaceship, in line with other forked code
+        if (dock_object && dock_object != target_spaceship && dock_object->canBeDockedBy(target_spaceship) != DockStyle::None && sf::length(dock_object->getPosition() - target_spaceship->getPosition()) < 1000.0f + dock_object->getRadius())
             break;
+
         dock_object = NULL;
     }
     return dock_object;


### PR DESCRIPTION
- Updated logic to use target_spaceship (ship the GUI control is attached to) rather than my_spaceship, in line with the rest of the LARP fork code